### PR TITLE
Fixes for Kotlin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,14 @@
                 <threadCount>4</threadCount>
                 <perCoreThreadCount>true</perCoreThreadCount>
                 <argLine>${argLine} -Xms512m -ea -Duser.timezone="UTC"</argLine>
+                <includes>
+                  <include>**/Test*.java</include>
+                  <include>**/*Test.java</include>
+                  <include>**/*TestCase.java</include>
+                  <include>**/Test*.kt</include>
+                  <include>**/*Test.kt</include>
+                  <include>**/*TestCase.kt</include>
+                </includes>
               </configuration>
             </execution>
           </executions>
@@ -491,6 +499,10 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>com.rimerosolutions.maven.plugins</groupId>
         <artifactId>wrapper-maven-plugin</artifactId>


### PR DESCRIPTION
Support surefire tests written in Kotlin, and always run Jacoco since the default surefire depends on it passing the java agent via the argline. We may need similar changes for Failsafe if Gil ever decides to write integration tests ;)

Verified new parent pom locally with build-resources and metrics-java-client.