### PR TITLE
Use Latest Build Resources with Default Findbugs Exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!--Dependency versions-->
-    <build-resources.version>1.0.5</build-resources.version>
+    <build-resources.version>1.0.6</build-resources.version>
     <checkstyle.version>6.16.1</checkstyle.version>
 
     <!--Plugin versions-->
@@ -102,7 +102,7 @@
     <nexus.staging.plugin.version>1.6.7</nexus.staging.plugin.version>
 
     <!-- Findbugs -->
-    <findbugs.exclude />
+    <findbugs.exclude>${project.build.directory}/findbugs.exclude.xml</findbugs.exclude>
 
     <!-- Code Coverage -->
     <jacoco.maven.plugin.version>0.7.7.201606060606</jacoco.maven.plugin.version>


### PR DESCRIPTION
Upgrade to latest build resources with default findbugs exclude and specify it in configuration.