### PR TITLE
Ignore Processing Warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
             <showWarnings>true</showWarnings>
             <compilerArgs>
               <arg>-Xlint:all</arg>
+              <arg>-Xlint:-processing</arg>
               <arg>-Werror</arg>
             </compilerArgs>
           </configuration>


### PR DESCRIPTION
The new version of Javassist is out which addresses some of the compiler warnings its use causes. However, when javac encounters an annotation processor it expects it to process all annotations (unless declared otherwise). This raises processing warnings and with Werror fails our builds. I think with Javassit at such a low level we're going to have to ignore those warnings across projects.