### PR TITLE
Nexus Staging Timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -588,6 +588,7 @@
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
             <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
             <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
             <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
             <description>Project ${project.groupId}:${project.artifactId}:${project.version} at ${buildNumber}</description>


### PR DESCRIPTION
Increase the timeout from its default of 5 min to 15 min; seeing consistent timeouts working with staging repositories.