### PR TITLE
Upgrade Checkstyle Plugin to be Compatible with Checkstyle Library

### DIFF
--- a/jdk-wrapper.sh
+++ b/jdk-wrapper.sh
@@ -19,13 +19,13 @@
 
 log_err() {
   l_prefix=$(date  +'%H:%M:%S')
-  printf "[%s] %s\n" "${l_prefix}" "$@" 1>&2;
+  printf "[%s] %s\\n" "${l_prefix}" "$@" 1>&2;
 }
 
 log_out() {
   if [ -n "${JDKW_VERBOSE}" ]; then
     l_prefix=$(date  +'%H:%M:%S')
-    printf "[%s] %s\n" "${l_prefix}" "$@"
+    printf "[%s] %s\\n" "${l_prefix}" "$@"
   fi
 }
 
@@ -56,7 +56,7 @@ checksum() {
     log_err "ERROR: No supported checksum command found!"
     exit 1
   fi
-  cat "${l_file}" | ${checksum_exec}
+  "${checksum_exec}" < "${l_file}"
 }
 
 rand() {
@@ -109,7 +109,7 @@ for arg in "$@"; do
   fi
   case "${arg}" in
     *\'*)
-       arg=`printf "%s" "$arg" | sed "s/'/'\"'\"'/g"`
+       arg=$(printf "%s" "$arg" | sed "s/'/'\"'\"'/g")
        ;;
     *) : ;;
   esac
@@ -157,7 +157,7 @@ fi
 if [ "${JDKW_RELEASE}" = "latest" ]; then
   latest_version_json="${TMPDIR:-/tmp}/jdkw-latest-version-$$.$(rand)"
   safe_command "curl ${curl_options} -f -k -L -o \"${latest_version_json}\" -H 'Accept: application/json' \"${JDKW_BASE_URI}/releases/latest\""
-  JDKW_RELEASE=$(cat "${latest_version_json}" | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+  JDKW_RELEASE=$(sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/' < "${latest_version_json}")
   rm -f "${latest_version_json}"
   log_out "Resolved latest version to ${JDKW_RELEASE}"
 fi
@@ -176,8 +176,24 @@ download_if_needed "${jdkw_impl}" "${jdkw_path}"
 download_if_needed "${jdkw_wrapper}" "${jdkw_path}"
 
 # Execute the provided command
-eval ${jdkw_path}/${jdkw_impl} ${command}
-result=$?
+
+# Run the command in the backround (with all the trouble that entails)
+# NOTE: Alternatively convert this to an exec if we don't need to output the
+# wrapper mismatch at the end; e.g. make that a hard precondition to running.
+trap 'kill -TERM ${impl_pid}' TERM INT
+"${jdkw_path}/${jdkw_impl}" "$@" &
+impl_pid=$!
+wait ${impl_pid} > /dev/null 2>&1
+wait_result=$?
+if [ ${wait_result} -ne 127 ]; then
+  result=${wait_result}
+fi
+trap - TERM INT
+wait ${impl_pid} > /dev/null 2>&1
+wait_result=$?
+if [ ${wait_result} -ne 127 ]; then
+  result=${wait_result}
+fi
 
 # Check whether this wrapper is the one specified for this version
 jdkw_download="${jdkw_path}/${jdkw_wrapper}"

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <!--Plugin versions-->
     <appassembler.maven.plugin.version>1.10</appassembler.maven.plugin.version>
     <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
-    <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
+    <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
     <maven.clean.plugin.version>2.2</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
     <maven.dependency.plugin.version>3.0.1</maven.dependency.plugin.version>


### PR DESCRIPTION
The checkstyle plugin and checkstyle library introduced an incompatibility which I failed to pick-up with the previous upgrade.